### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
need to update 

error: Source option 6 is no longer supported. Use 7 or later.
[[1;31mERROR[m] error: Target option 6 is no longer supported. Use 7 or later.